### PR TITLE
support transmission data pre-worker to post-worker

### DIFF
--- a/src/main/java/org/jeasy/flows/engine/WorkFlowEngine.java
+++ b/src/main/java/org/jeasy/flows/engine/WorkFlowEngine.java
@@ -1,28 +1,26 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.engine;
 
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.workflow.WorkFlow;
 
@@ -33,12 +31,12 @@ import org.jeasy.flows.workflow.WorkFlow;
  */
 public interface WorkFlowEngine {
 
-    /**
-     * Run the given workflow and return its report.
-     *
-     * @param workFlow to run
-     * @return workflow report
-     */
-    WorkReport run(WorkFlow workFlow);
+  /**
+   * Run the given workflow and return its report.
+   *
+   * @param workFlow to run
+   * @return workflow report
+   */
+  WorkReport run(WorkFlow workFlow, WorkContext context);
 
 }

--- a/src/main/java/org/jeasy/flows/engine/WorkFlowEngineBuilder.java
+++ b/src/main/java/org/jeasy/flows/engine/WorkFlowEngineBuilder.java
@@ -1,31 +1,25 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.engine;
 
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 /**
@@ -35,35 +29,25 @@ import java.util.logging.Logger;
  */
 public class WorkFlowEngineBuilder {
 
-    private static final Logger LOGGER = Logger.getLogger(WorkFlowEngineBuilder.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(WorkFlowEngineBuilder.class.getName());
 
-    static {
-        try {
-            if (System.getProperty("java.util.logging.config.file") == null &&
-                    System.getProperty("java.util.logging.config.class") == null) {
-                LogManager.getLogManager().readConfiguration(WorkFlowEngineBuilder.class.getResourceAsStream("/logging.properties"));
-            }
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Unable to load log configuration file", e);
-        }
-    }
+  /**
+   * Create a new {@link WorkFlowEngineBuilder}.
+   * 
+   * @return a new {@link WorkFlowEngineBuilder}.
+   */
+  public static WorkFlowEngineBuilder aNewWorkFlowEngine() {
+    return new WorkFlowEngineBuilder();
+  }
 
-    /**
-     * Create a new {@link WorkFlowEngineBuilder}.
-     * @return a new {@link WorkFlowEngineBuilder}.
-     */
-    public static WorkFlowEngineBuilder aNewWorkFlowEngine() {
-        return new WorkFlowEngineBuilder();
-    }
+  private WorkFlowEngineBuilder() {}
 
-    private WorkFlowEngineBuilder() {
-    }
-
-    /**
-     * Create a new {@link WorkFlowEngine}.
-     * @return a new {@link WorkFlowEngine}.
-     */
-    public WorkFlowEngine build() {
-        return new WorkFlowEngineImpl();
-    }
+  /**
+   * Create a new {@link WorkFlowEngine}.
+   * 
+   * @return a new {@link WorkFlowEngine}.
+   */
+  public WorkFlowEngine build() {
+    return new WorkFlowEngineImpl();
+  }
 }

--- a/src/main/java/org/jeasy/flows/engine/WorkFlowEngineImpl.java
+++ b/src/main/java/org/jeasy/flows/engine/WorkFlowEngineImpl.java
@@ -1,41 +1,37 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.engine;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.workflow.WorkFlow;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 class WorkFlowEngineImpl implements WorkFlowEngine {
 
-    private static final Logger LOGGER = Logger.getLogger(WorkFlowEngineImpl.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(WorkFlowEngineImpl.class.getName());
 
-    public WorkReport run(WorkFlow workFlow) {
-        LOGGER.log(Level.INFO, "Running workflow ''{0}''", workFlow.getName());
-        return workFlow.call();
-    }
+  public WorkReport run(WorkFlow workFlow) {
+    LOGGER.log(Level.INFO, "Running workflow ''{0}''", workFlow.getName());
+    return workFlow.call(null);
+  }
 
 }

--- a/src/main/java/org/jeasy/flows/engine/WorkFlowEngineImpl.java
+++ b/src/main/java/org/jeasy/flows/engine/WorkFlowEngineImpl.java
@@ -22,6 +22,7 @@ package org.jeasy.flows.engine;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.workflow.WorkFlow;
 
@@ -29,9 +30,10 @@ class WorkFlowEngineImpl implements WorkFlowEngine {
 
   private static final Logger LOGGER = Logger.getLogger(WorkFlowEngineImpl.class.getName());
 
-  public WorkReport run(WorkFlow workFlow) {
+  public WorkReport run(WorkFlow workFlow, WorkContext context) {
     LOGGER.log(Level.INFO, "Running workflow ''{0}''", workFlow.getName());
-    return workFlow.call(null);
+
+    return workFlow.call(null, context);
   }
 
 }

--- a/src/main/java/org/jeasy/flows/work/DefaultWorkReport.java
+++ b/src/main/java/org/jeasy/flows/work/DefaultWorkReport.java
@@ -20,8 +20,8 @@
  */
 package org.jeasy.flows.work;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Default implementation of {@link WorkReport}.
@@ -43,7 +43,7 @@ public class DefaultWorkReport<T> implements WorkReport<T> {
    */
   public DefaultWorkReport(WorkStatus status) {
     this.status = status;
-    collectData = new ConcurrentHashMap<>();
+    collectData = new HashMap<>();
   }
 
   /**
@@ -83,7 +83,7 @@ public class DefaultWorkReport<T> implements WorkReport<T> {
   }
 
   public void setCollectData(Map<String, T> collectData) {
-    collectData.putAll(collectData);
+    this.collectData.putAll(collectData);
   }
 
 

--- a/src/main/java/org/jeasy/flows/work/DefaultWorkReport.java
+++ b/src/main/java/org/jeasy/flows/work/DefaultWorkReport.java
@@ -1,71 +1,91 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.work;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Default implementation of {@link WorkReport}.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * @param <T>
  */
-public class DefaultWorkReport implements WorkReport {
+public class DefaultWorkReport<T> implements WorkReport<T> {
 
-    private WorkStatus status;
-    private Throwable error;
+  private WorkStatus status;
+  private Throwable error;
 
-    /**
-     * Create a new {@link DefaultWorkReport}.
-     *
-     * @param status of work
-     */
-    public DefaultWorkReport(WorkStatus status) {
-        this.status = status;
-    }
+  private Map<String, T> collectData;
 
-    /**
-     * Create a new {@link DefaultWorkReport}.
-     *
-     * @param status of work
-     * @param error if any
-     */
-    public DefaultWorkReport(WorkStatus status, Throwable error) {
-        this(status);
-        this.error = error;
-    }
+  /**
+   * Create a new {@link DefaultWorkReport}.
+   *
+   * @param status of work
+   */
+  public DefaultWorkReport(WorkStatus status) {
+    this.status = status;
+    collectData = new ConcurrentHashMap<>();
+  }
 
-    public WorkStatus getStatus() {
-        return status;
-    }
+  /**
+   * Create a new {@link DefaultWorkReport}.
+   *
+   * @param status of work
+   * @param error if any
+   */
+  public DefaultWorkReport(WorkStatus status, Throwable error) {
+    this(status);
+    this.error = error;
+  }
 
-    public Throwable getError() {
-        return error;
-    }
+  public WorkStatus getStatus() {
+    return status;
+  }
 
-    @Override
-    public String toString() {
-        return "DefaultWorkReport {" +
-                "status=" + status +
-                ", error=" + (error == null ? "''" : error) +
-                '}';
-    }
+  public Throwable getError() {
+    return error;
+  }
+
+  @Override
+  public String toString() {
+    return "DefaultWorkReport {" + "status=" + status + ", error=" + (error == null ? "''" : error)
+        + '}';
+  }
+
+  /**
+   * Title: getCollectData. Description:
+   * 
+   * @return .
+   * @see org.jeasy.flows.work.WorkReport#getCollectData()
+   */
+  @Override
+  public Map<String, T> getCollectData() {
+    return collectData;
+  }
+
+  public void setCollectData(Map<String, T> collectData) {
+    collectData.putAll(collectData);
+  }
+
+
+
 }

--- a/src/main/java/org/jeasy/flows/work/DefineCallable.java
+++ b/src/main/java/org/jeasy/flows/work/DefineCallable.java
@@ -1,0 +1,27 @@
+/**
+ * All rights Reserved, Designed By www.didichuxing.com.
+ * 
+ * @Title: Callable.java <\br>
+ * @Package org.jeasy.flows.work <\br>
+ * @Description: TODO(用一句话描述该文件做什么)<\br>
+ * @author: zyt <\br>
+ * @date: 2018年12月13日 下午7:04:36 <\br>
+ * @version V1.0 <\br>
+ * @Copyright: 2018 www.didichuxing Inc. All rights reserved.<\br>
+ */
+
+package org.jeasy.flows.work;
+
+import java.util.List;
+
+/**
+ * @ClassName: Callable .
+ * @Description:TODO(这里用一句话描述这个类的作用) <\br>
+ * @author: zyt <\br>
+ * @date: 2018年12月13日 下午7:04:36 <\br>
+ * 
+ */
+public interface DefineCallable<T> {
+
+  T call(List<T> param);
+}

--- a/src/main/java/org/jeasy/flows/work/DefineCallable.java
+++ b/src/main/java/org/jeasy/flows/work/DefineCallable.java
@@ -23,5 +23,5 @@ import java.util.List;
  */
 public interface DefineCallable<T> {
 
-  T call(List<T> param);
+  T call(List<T> param, WorkContext context);
 }

--- a/src/main/java/org/jeasy/flows/work/DefineCallable.java
+++ b/src/main/java/org/jeasy/flows/work/DefineCallable.java
@@ -1,5 +1,5 @@
 /**
- * All rights Reserved, Designed By www.didichuxing.com.
+ * All rights Reserved
  * 
  * @Title: Callable.java <\br>
  * @Package org.jeasy.flows.work <\br>
@@ -7,7 +7,7 @@
  * @author: zyt <\br>
  * @date: 2018年12月13日 下午7:04:36 <\br>
  * @version V1.0 <\br>
- * @Copyright: 2018 www.didichuxing Inc. All rights reserved.<\br>
+ * @Copyright: 2018 <\br>
  */
 
 package org.jeasy.flows.work;

--- a/src/main/java/org/jeasy/flows/work/NoOpWork.java
+++ b/src/main/java/org/jeasy/flows/work/NoOpWork.java
@@ -44,7 +44,7 @@ public class NoOpWork implements Work {
    * @see org.jeasy.flows.work.Work#call(java.util.List)
    */
   @Override
-  public WorkReport call(List param) {
+  public WorkReport call(List param, WorkContext context) {
     return new DefaultWorkReport(WorkStatus.COMPLETED);
 
   }

--- a/src/main/java/org/jeasy/flows/work/NoOpWork.java
+++ b/src/main/java/org/jeasy/flows/work/NoOpWork.java
@@ -1,28 +1,26 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.work;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -32,13 +30,25 @@ import java.util.UUID;
  */
 public class NoOpWork implements Work {
 
-    @Override
-    public String getName() {
-        return UUID.randomUUID().toString();
-    }
+  @Override
+  public String getName() {
+    return UUID.randomUUID().toString();
+  }
 
-    @Override
-    public WorkReport call() {
-        return new DefaultWorkReport(WorkStatus.COMPLETED);
-    }
+
+  /**
+   * Title: call. Description:
+   * 
+   * @param param
+   * @return .
+   * @see org.jeasy.flows.work.Work#call(java.util.List)
+   */
+  @Override
+  public WorkReport call(List param) {
+    return new DefaultWorkReport(WorkStatus.COMPLETED);
+
+  }
+
+
+
 }

--- a/src/main/java/org/jeasy/flows/work/Work.java
+++ b/src/main/java/org/jeasy/flows/work/Work.java
@@ -35,6 +35,6 @@ public interface Work<T> extends DefineCallable<WorkReport<T>> {
 
   String getName();
 
-  WorkReport<T> call(List<WorkReport<T>> param);
+  WorkReport<T> call(List<WorkReport<T>> param, WorkContext context);
 
 }

--- a/src/main/java/org/jeasy/flows/work/Work.java
+++ b/src/main/java/org/jeasy/flows/work/Work.java
@@ -1,25 +1,22 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.work;
 
@@ -28,15 +25,15 @@ import java.util.concurrent.Callable;
 /**
  * Implementations of this interface must:
  * <ul>
- *     <li>catch exceptions and return {@link WorkStatus#FAILED}</li>
- *     <li>make sure the work in finished in a finite amount of time</li>
+ * <li>catch exceptions and return {@link WorkStatus#FAILED}</li>
+ * <li>make sure the work in finished in a finite amount of time</li>
  * </ul>
  *
  * Work name must be unique within a workflow.
  */
-public interface Work extends Callable<WorkReport> {
+public interface Work<T> extends Callable<WorkReport<T>> {
 
-    String getName();
+  String getName();
 
-    WorkReport call();
+  WorkReport<T> call();
 }

--- a/src/main/java/org/jeasy/flows/work/Work.java
+++ b/src/main/java/org/jeasy/flows/work/Work.java
@@ -20,7 +20,7 @@
  */
 package org.jeasy.flows.work;
 
-import java.util.concurrent.Callable;
+import java.util.List;
 
 /**
  * Implementations of this interface must:
@@ -31,9 +31,10 @@ import java.util.concurrent.Callable;
  *
  * Work name must be unique within a workflow.
  */
-public interface Work<T> extends Callable<WorkReport<T>> {
+public interface Work<T> extends DefineCallable<WorkReport<T>> {
 
   String getName();
 
-  WorkReport<T> call();
+  WorkReport<T> call(List<WorkReport<T>> param);
+
 }

--- a/src/main/java/org/jeasy/flows/work/WorkContext.java
+++ b/src/main/java/org/jeasy/flows/work/WorkContext.java
@@ -1,0 +1,23 @@
+/**  
+ * All rights Reserved, Designed By www.didichuxing.com.
+ * @Title:  WorkContext.java   <\br>
+ * @Package org.jeasy.flows.work   <\br>
+ * @Description:    TODO(用一句话描述该文件做什么)<\br>   
+ * @author: zyt     <\br>
+ * @date:   2018年12月14日 下午6:31:44   <\br>
+ * @version V1.0 <\br>
+ * @Copyright: 2018 www.didichuxing Inc. All rights reserved.<\br> 
+ */
+
+package org.jeasy.flows.work;
+
+/**   
+ * @ClassName:  WorkContext   .
+ * @Description:TODO(这里用一句话描述这个类的作用)  <\br> 
+ * @author: zyt <\br>
+ * @date:   2018年12月14日 下午6:31:44   <\br>
+ *   
+ */
+public interface WorkContext {
+
+}

--- a/src/main/java/org/jeasy/flows/work/WorkReport.java
+++ b/src/main/java/org/jeasy/flows/work/WorkReport.java
@@ -1,46 +1,48 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.work;
+
+import java.util.Map;
 
 /**
  * Report of work execution.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public interface WorkReport {
+public interface WorkReport<T> {
 
-    /**
-     * Get work execution status.
-     * @return execution status
-     */
-    WorkStatus getStatus();
+  /**
+   * Get work execution status.
+   * 
+   * @return execution status
+   */
+  WorkStatus getStatus();
 
-    /**
-     * Get error if any.
-     *
-     * @return error
-     */
-    Throwable getError();
+  Map<String, T> getCollectData();
+
+  /**
+   * Get error if any.
+   *
+   * @return error
+   */
+  Throwable getError();
 
 }

--- a/src/main/java/org/jeasy/flows/workflow/AbstractWorkFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/AbstractWorkFlow.java
@@ -1,37 +1,37 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
 abstract class AbstractWorkFlow implements WorkFlow {
 
-    private String name;
+  private String name;
 
-    AbstractWorkFlow(String name) {
-        this.name = name;
-    }
+  AbstractWorkFlow(String name) {
+    this.name = name;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
+
+
+
 }

--- a/src/main/java/org/jeasy/flows/workflow/ConditionalFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/ConditionalFlow.java
@@ -1,43 +1,41 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 import org.jeasy.flows.work.NoOpWork;
 import org.jeasy.flows.work.Work;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.work.WorkReportPredicate;
 
-import java.util.UUID;
-
 /**
  * A conditional flow is defined by 4 artifacts:
  *
  * <ul>
- *     <li>The work to execute first</li>
- *     <li>A predicate for the conditional logic</li>
- *     <li>The work to execute if the predicate is satisfied</li>
- *     <li>The work to execute if the predicate is not satisfied (optional)</li>
+ * <li>The work to execute first</li>
+ * <li>A predicate for the conditional logic</li>
+ * <li>The work to execute if the predicate is satisfied</li>
+ * <li>The work to execute if the predicate is not satisfied (optional)</li>
  * </ul>
  *
  * @see ConditionalFlow.Builder
@@ -46,77 +44,81 @@ import java.util.UUID;
  */
 public class ConditionalFlow extends AbstractWorkFlow {
 
+  private Work toExecute, nextOnPredicateSuccess, nextOnPredicateFailure;
+  private WorkReportPredicate predicate;
+
+  ConditionalFlow(String name, Work toExecute, Work nextOnPredicateSuccess,
+      Work nextOnPredicateFailure, WorkReportPredicate predicate) {
+    super(name);
+    this.toExecute = toExecute;
+    this.nextOnPredicateSuccess = nextOnPredicateSuccess;
+    this.nextOnPredicateFailure = nextOnPredicateFailure;
+    this.predicate = predicate;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public WorkReport call(List param) {
+    WorkReport jobReport = toExecute.call(param);
+    if (predicate.apply(jobReport)) {
+      jobReport = nextOnPredicateSuccess.call(Arrays.asList(jobReport));
+    } else {
+      if (nextOnPredicateFailure != null && !(nextOnPredicateFailure instanceof NoOpWork)) { // else
+        // optional
+        jobReport = nextOnPredicateFailure.call(Arrays.asList(jobReport));
+      }
+    }
+    return jobReport;
+  }
+
+  public static class Builder {
+
+    private String name;
     private Work toExecute, nextOnPredicateSuccess, nextOnPredicateFailure;
     private WorkReportPredicate predicate;
 
-    ConditionalFlow(String name, Work toExecute, Work nextOnPredicateSuccess, Work nextOnPredicateFailure, WorkReportPredicate predicate) {
-        super(name);
-        this.toExecute = toExecute;
-        this.nextOnPredicateSuccess = nextOnPredicateSuccess;
-        this.nextOnPredicateFailure = nextOnPredicateFailure;
-        this.predicate = predicate;
+    private Builder() {
+      this.name = UUID.randomUUID().toString();
+      this.toExecute = new NoOpWork();
+      this.nextOnPredicateSuccess = new NoOpWork();
+      this.nextOnPredicateFailure = new NoOpWork();
+      this.predicate = WorkReportPredicate.ALWAYS_FALSE;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public WorkReport call() {
-        WorkReport jobReport = toExecute.call();
-        if (predicate.apply(jobReport)) {
-            jobReport = nextOnPredicateSuccess.call();
-        } else {
-            if (nextOnPredicateFailure != null && !(nextOnPredicateFailure instanceof NoOpWork)) { // else is optional
-                jobReport = nextOnPredicateFailure.call();
-            }
-        }
-        return jobReport;
+    public static ConditionalFlow.Builder aNewConditionalFlow() {
+      return new ConditionalFlow.Builder();
     }
 
-    public static class Builder {
-
-        private String name;
-        private Work toExecute, nextOnPredicateSuccess, nextOnPredicateFailure;
-        private WorkReportPredicate predicate;
-
-        private Builder() {
-            this.name = UUID.randomUUID().toString();
-            this.toExecute = new NoOpWork();
-            this.nextOnPredicateSuccess = new NoOpWork();
-            this.nextOnPredicateFailure = new NoOpWork();
-            this.predicate = WorkReportPredicate.ALWAYS_FALSE;
-        }
-
-        public static ConditionalFlow.Builder aNewConditionalFlow() {
-            return new ConditionalFlow.Builder();
-        }
-
-        public ConditionalFlow.Builder named(String name) {
-            this.name = name;
-            return this;
-        }
-
-        public ConditionalFlow.Builder execute(Work work) {
-            this.toExecute = work;
-            return this;
-        }
-
-        public ConditionalFlow.Builder when(WorkReportPredicate predicate) {
-            this.predicate = predicate;
-            return this;
-        }
-
-        public ConditionalFlow.Builder then(Work work) {
-            this.nextOnPredicateSuccess = work;
-            return this;
-        }
-
-        public ConditionalFlow.Builder otherwise(Work work) {
-            this.nextOnPredicateFailure = work;
-            return this;
-        }
-
-        public ConditionalFlow build() {
-            return new ConditionalFlow(name, toExecute, nextOnPredicateSuccess, nextOnPredicateFailure, predicate);
-        }
+    public ConditionalFlow.Builder named(String name) {
+      this.name = name;
+      return this;
     }
+
+    public ConditionalFlow.Builder execute(Work work) {
+      this.toExecute = work;
+      return this;
+    }
+
+    public ConditionalFlow.Builder when(WorkReportPredicate predicate) {
+      this.predicate = predicate;
+      return this;
+    }
+
+    public ConditionalFlow.Builder then(Work work) {
+      this.nextOnPredicateSuccess = work;
+      return this;
+    }
+
+    public ConditionalFlow.Builder otherwise(Work work) {
+      this.nextOnPredicateFailure = work;
+      return this;
+    }
+
+    public ConditionalFlow build() {
+      return new ConditionalFlow(name, toExecute, nextOnPredicateSuccess, nextOnPredicateFailure,
+          predicate);
+    }
+  }
+
 }

--- a/src/main/java/org/jeasy/flows/workflow/ConditionalFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/ConditionalFlow.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.UUID;
 import org.jeasy.flows.work.NoOpWork;
 import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.work.WorkReportPredicate;
 
@@ -59,14 +60,14 @@ public class ConditionalFlow extends AbstractWorkFlow {
   /**
    * {@inheritDoc}
    */
-  public WorkReport call(List param) {
-    WorkReport jobReport = toExecute.call(param);
+  public WorkReport call(List param, WorkContext context) {
+    WorkReport jobReport = toExecute.call(param, context);
     if (predicate.apply(jobReport)) {
-      jobReport = nextOnPredicateSuccess.call(Arrays.asList(jobReport));
+      jobReport = nextOnPredicateSuccess.call(Arrays.asList(jobReport), context);
     } else {
       if (nextOnPredicateFailure != null && !(nextOnPredicateFailure instanceof NoOpWork)) { // else
         // optional
-        jobReport = nextOnPredicateFailure.call(Arrays.asList(jobReport));
+        jobReport = nextOnPredicateFailure.call(Arrays.asList(jobReport), context);
       }
     }
     return jobReport;

--- a/src/main/java/org/jeasy/flows/workflow/ParallelFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/ParallelFlow.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 
 /**
@@ -54,9 +55,9 @@ public class ParallelFlow extends AbstractWorkFlow {
   /**
    * {@inheritDoc}
    */
-  public ParallelFlowReport call(List param) {
+  public ParallelFlowReport call(List param, WorkContext context) {
     ParallelFlowReport workFlowReport = new ParallelFlowReport();
-    List<WorkReport> workReports = workExecutor.executeInParallel(works, param);
+    List<WorkReport> workReports = workExecutor.executeInParallel(works, param, context);
     workFlowReport.setReports(workReports);
     return workFlowReport;
   }

--- a/src/main/java/org/jeasy/flows/workflow/ParallelFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/ParallelFlow.java
@@ -1,35 +1,31 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
-
-import org.jeasy.flows.work.Work;
-import org.jeasy.flows.work.WorkReport;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkReport;
 
 /**
  * A parallel flow executes a set of works in parallel.
@@ -37,59 +33,60 @@ import java.util.UUID;
  * The status of a parallel flow execution is defined as:
  *
  * <ul>
- *     <li>{@link org.jeasy.flows.work.WorkStatus#COMPLETED}: If all works have successfully completed</li>
- *     <li>{@link org.jeasy.flows.work.WorkStatus#FAILED}: If one of the works has failed</li>
+ * <li>{@link org.jeasy.flows.work.WorkStatus#COMPLETED}: If all works have successfully
+ * completed</li>
+ * <li>{@link org.jeasy.flows.work.WorkStatus#FAILED}: If one of the works has failed</li>
  * </ul>
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
 public class ParallelFlow extends AbstractWorkFlow {
 
-    private List<Work> works = new ArrayList<>();
-    private ParallelFlowExecutor workExecutor;
+  private List<Work> works = new ArrayList<>();
+  private ParallelFlowExecutor workExecutor;
 
-    ParallelFlow(String name, List<Work> works, ParallelFlowExecutor parallelFlowExecutor) {
-        super(name);
-        this.works.addAll(works);
-        this.workExecutor = parallelFlowExecutor;
+  ParallelFlow(String name, List<Work> works, ParallelFlowExecutor parallelFlowExecutor) {
+    super(name);
+    this.works.addAll(works);
+    this.workExecutor = parallelFlowExecutor;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public ParallelFlowReport call(List param) {
+    ParallelFlowReport workFlowReport = new ParallelFlowReport();
+    List<WorkReport> workReports = workExecutor.executeInParallel(works, param);
+    workFlowReport.setReports(workReports);
+    return workFlowReport;
+  }
+
+  public static class Builder {
+
+    private String name;
+    private List<Work> works;
+
+    private Builder() {
+      this.name = UUID.randomUUID().toString();
+      this.works = new ArrayList<>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public ParallelFlowReport call() {
-        ParallelFlowReport workFlowReport = new ParallelFlowReport();
-        List<WorkReport> workReports = workExecutor.executeInParallel(works);
-        workFlowReport.addAll(workReports);
-        return workFlowReport;
+    public static ParallelFlow.Builder aNewParallelFlow() {
+      return new ParallelFlow.Builder();
     }
 
-    public static class Builder {
-
-        private String name;
-        private List<Work> works;
-
-        private Builder() {
-            this.name = UUID.randomUUID().toString();
-            this.works = new ArrayList<>();
-        }
-
-        public static ParallelFlow.Builder aNewParallelFlow() {
-            return new ParallelFlow.Builder();
-        }
-
-        public ParallelFlow.Builder named(String name) {
-            this.name = name;
-            return this;
-        }
-
-        public ParallelFlow.Builder execute(Work... works) {
-            this.works.addAll(Arrays.asList(works));
-            return this;
-        }
-
-        public ParallelFlow build() {
-            return new ParallelFlow(name, works, new ParallelFlowExecutor());
-        }
+    public ParallelFlow.Builder named(String name) {
+      this.name = name;
+      return this;
     }
+
+    public ParallelFlow.Builder execute(Work... works) {
+      this.works.addAll(Arrays.asList(works));
+      return this;
+    }
+
+    public ParallelFlow build() {
+      return new ParallelFlow(name, works, new ParallelFlowExecutor());
+    }
+  }
 }

--- a/src/main/java/org/jeasy/flows/workflow/ParallelFlowExecutor.java
+++ b/src/main/java/org/jeasy/flows/workflow/ParallelFlowExecutor.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 
 class ParallelFlowExecutor {
@@ -55,7 +56,8 @@ class ParallelFlowExecutor {
         Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());;
   }
 
-  List<WorkReport> executeInParallel(List<Work> works, List<WorkReport> reports) {
+  List<WorkReport> executeInParallel(List<Work> works, List<WorkReport> reports,
+      WorkContext context) {
     // re-init in case it has been shut down in a previous run (See question 3)
     if (workExecutor.isShutdown()) {
       workExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
@@ -69,7 +71,7 @@ class ParallelFlowExecutor {
 
         @Override
         public WorkReport call() throws Exception {
-          return work.call(reports);
+          return work.call(reports, context);
         }
 
 

--- a/src/main/java/org/jeasy/flows/workflow/ParallelFlowExecutor.java
+++ b/src/main/java/org/jeasy/flows/workflow/ParallelFlowExecutor.java
@@ -1,94 +1,107 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
-
-import org.jeasy.flows.work.Work;
-import org.jeasy.flows.work.WorkReport;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkReport;
 
 class ParallelFlowExecutor {
 
-    private static final Logger LOGGER = Logger.getLogger(ParallelFlowExecutor.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(ParallelFlowExecutor.class.getName());
 
-    /*
-     * TODO Making the executor configurable requires to answer the following questions first:
-     *
-     * 1. If the user provides a custom executor, when should it be shutdown? -> Could be documented so the user shuts it down himself
-     * 2. If the user provides a custom executor which is shared by multiple parallel flow, shutting it down here (as currently done) may impact other flows
-     * 3. If it is decided to shut down the executor at the end of the parallel flow, the parallel flow could not be re-run (in a repeat flow for example) since the executor will be in an illegal state
-     */
-    private ExecutorService workExecutor;
+  /*
+   * TODO Making the executor configurable requires to answer the following questions first:
+   *
+   * 1. If the user provides a custom executor, when should it be shutdown? -> Could be documented
+   * so the user shuts it down himself 2. If the user provides a custom executor which is shared by
+   * multiple parallel flow, shutting it down here (as currently done) may impact other flows 3. If
+   * it is decided to shut down the executor at the end of the parallel flow, the parallel flow
+   * could not be re-run (in a repeat flow for example) since the executor will be in an illegal
+   * state
+   */
+  private ExecutorService workExecutor;
 
-    ParallelFlowExecutor() {
-        this.workExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());;
+  ParallelFlowExecutor() {
+    this.workExecutor =
+        Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());;
+  }
+
+  List<WorkReport> executeInParallel(List<Work> works, List<WorkReport> reports) {
+    // re-init in case it has been shut down in a previous run (See question 3)
+    if (workExecutor.isShutdown()) {
+      workExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
     }
 
-    List<WorkReport> executeInParallel(List<Work> works) {
-        // re-init in case it has been shut down in a previous run (See question 3)
-        if(workExecutor.isShutdown()) {
-            workExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+    // submit works to be executed in parallel
+    Map<Work, Future<WorkReport>> reportFutures = new HashMap<>();
+    for (Work work : works) {
+
+      Future<WorkReport> reportFuture = workExecutor.submit(new Callable<WorkReport>() {
+
+        @Override
+        public WorkReport call() throws Exception {
+          return work.call(reports);
         }
 
-        // submit works to be executed in parallel
-        Map<Work, Future<WorkReport>> reportFutures = new HashMap<>();
-        for (Work work : works) {
-            Future<WorkReport> reportFuture = workExecutor.submit(work);
-            reportFutures.put(work, reportFuture);
-        }
 
-        // poll for work completion
-        int finishedWorks = works.size();
-        // FIXME polling futures for completion, not sure this is the best way to run callables in parallel and wait them for completion (use CompletionService??)
-        while (finishedWorks > 0) {
-            for (Future<WorkReport> future : reportFutures.values()) {
-                if (future != null && future.isDone()) {
-                        finishedWorks--;
-                }
-            }
-        }
-
-        // gather reports
-        List<WorkReport> workReports = new ArrayList<>();
-        for (Map.Entry<Work, Future<WorkReport>> entry : reportFutures.entrySet()) {
-            try {
-                workReports.add(entry.getValue().get());
-            } catch (InterruptedException | ExecutionException e) {
-                LOGGER.log(Level.WARNING, "Unable to get work report of work ''{0}''", entry.getKey().getName());
-            }
-        }
-
-        workExecutor.shutdown(); // because if not, the workflow engine may run forever.. (See question 2).
-        return workReports;
+      });
+      reportFutures.put(work, reportFuture);
     }
+
+    // poll for work completion
+    int finishedWorks = works.size();
+    // FIXME polling futures for completion, not sure this is the best way to run callables in
+    // parallel and wait them for completion (use CompletionService??)
+    while (finishedWorks > 0) {
+      for (Future<WorkReport> future : reportFutures.values()) {
+        if (future != null && future.isDone()) {
+          finishedWorks--;
+        }
+      }
+    }
+
+    // gather reports
+    List<WorkReport> workReports = new ArrayList<>();
+    for (Map.Entry<Work, Future<WorkReport>> entry : reportFutures.entrySet()) {
+      try {
+        workReports.add(entry.getValue().get());
+      } catch (InterruptedException | ExecutionException e) {
+        LOGGER.log(Level.WARNING, "Unable to get work report of work ''{0}''",
+            entry.getKey().getName());
+      }
+    }
+
+    workExecutor.shutdown(); // because if not, the workflow engine may run forever.. (See question
+                             // 2).
+    return workReports;
+  }
 }

--- a/src/main/java/org/jeasy/flows/workflow/ParallelFlowReport.java
+++ b/src/main/java/org/jeasy/flows/workflow/ParallelFlowReport.java
@@ -1,108 +1,132 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
-import org.jeasy.flows.work.WorkReport;
-import org.jeasy.flows.work.WorkStatus;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jeasy.flows.work.WorkReport;
+import org.jeasy.flows.work.WorkStatus;
 
 /**
  * Aggregate report of all works reports.
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public class ParallelFlowReport implements WorkReport {
+public class ParallelFlowReport<T> implements WorkReport<T> {
 
-    private List<WorkReport> reports;
+  private List<WorkReport> reports;
 
-    /**
-     * Create a new {@link ParallelFlowReport}.
-     */
-    public ParallelFlowReport() {
-        this(new ArrayList<>());
+  private Map<String, T> collectData;
+
+  /**
+   * Create a new {@link ParallelFlowReport}.
+   */
+  public ParallelFlowReport() {
+    this(new ArrayList<>());
+    collectData = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Create a new {@link ParallelFlowReport}.
+   * 
+   * @param reports of works executed in parallel
+   */
+  public ParallelFlowReport(List<WorkReport> reports) {
+    this.reports = reports;
+  }
+
+  /**
+   * Get partial reports.
+   *
+   * @return partial reports
+   */
+  public List<WorkReport> getReports() {
+    return reports;
+  }
+
+  void add(WorkReport workReport) {
+    reports.add(workReport);
+  }
+
+  void addAll(List<WorkReport> workReports) {
+    reports.addAll(workReports);
+  }
+
+  /**
+   * Return the status of the parallel flow.
+   *
+   * The status of a parallel flow is defined as follows:
+   *
+   * <ul>
+   * <li>{@link org.jeasy.flows.work.WorkStatus#COMPLETED}: If all works have successfully
+   * completed</li>
+   * <li>{@link org.jeasy.flows.work.WorkStatus#FAILED}: If one of the works has failed</li>
+   * </ul>
+   * 
+   * @return workflow status
+   */
+  public WorkStatus getStatus() {
+    for (WorkReport report : reports) {
+      if (report.getStatus().equals(WorkStatus.FAILED)) {
+        return WorkStatus.FAILED;
+      }
+      collectData.putAll(report.getCollectData());
     }
+    return WorkStatus.COMPLETED;
+  }
 
-    /**
-     * Create a new {@link ParallelFlowReport}.
-     * @param reports of works executed in parallel
-     */
-    public ParallelFlowReport(List<WorkReport> reports) {
-        this.reports = reports;
+  /**
+   * Return the first error of partial reports.
+   *
+   * @return the first error of partial reports.
+   */
+  @Override
+  public Throwable getError() {
+    for (WorkReport report : reports) {
+      Throwable error = report.getError();
+      if (error != null) {
+        return error;
+      }
     }
+    return null;
+  }
 
-    /**
-     * Get partial reports.
-     *
-     * @return partial reports
-     */
-    public List<WorkReport> getReports() {
-        return reports;
-    }
 
-    void add(WorkReport workReport) {
-        reports.add(workReport);
-    }
+  public void setReports(List<WorkReport> reports) {
+    this.reports = reports;
+  }
 
-    void addAll(List<WorkReport> workReports) {
-        reports.addAll(workReports);
-    }
+  /**
+   * Title: getCollectData. Description:
+   * 
+   * @return .
+   * @see org.jeasy.flows.work.WorkReport#getCollectData()
+   */
+  @Override
+  public Map<String, T> getCollectData() {
+    return collectData;
+  }
 
-    /**
-     * Return the status of the parallel flow.
-     *
-     * The status of a parallel flow is defined as follows:
-     *
-     * <ul>
-     *     <li>{@link org.jeasy.flows.work.WorkStatus#COMPLETED}: If all works have successfully completed</li>
-     *     <li>{@link org.jeasy.flows.work.WorkStatus#FAILED}: If one of the works has failed</li>
-     * </ul>
-     * @return workflow status
-     */
-    public WorkStatus getStatus() {
-        for (WorkReport report : reports) {
-            if (report.getStatus().equals(WorkStatus.FAILED)) {
-                return WorkStatus.FAILED;
-            }
-        }
-        return WorkStatus.COMPLETED;
-    }
 
-    /**
-     * Return the first error of partial reports.
-     *
-     * @return the first error of partial reports.
-     */
-    @Override
-    public Throwable getError() {
-        for (WorkReport report : reports) {
-            Throwable error = report.getError();
-            if (error != null) {
-                return error;
-            }
-        }
-        return null;
-    }
+
 }

--- a/src/main/java/org/jeasy/flows/workflow/ParallelFlowReport.java
+++ b/src/main/java/org/jeasy/flows/workflow/ParallelFlowReport.java
@@ -90,7 +90,6 @@ public class ParallelFlowReport<T> implements WorkReport<T> {
       if (report.getStatus().equals(WorkStatus.FAILED)) {
         return WorkStatus.FAILED;
       }
-      collectData.putAll(report.getCollectData());
     }
     return WorkStatus.COMPLETED;
   }
@@ -124,6 +123,10 @@ public class ParallelFlowReport<T> implements WorkReport<T> {
    */
   @Override
   public Map<String, T> getCollectData() {
+    reports.forEach(t -> {
+      collectData.putAll(t.getCollectData());
+
+    });
     return collectData;
   }
 

--- a/src/main/java/org/jeasy/flows/workflow/RepeatFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/RepeatFlow.java
@@ -1,34 +1,31 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
+import java.util.List;
+import java.util.UUID;
 import org.jeasy.flows.work.NoOpWork;
 import org.jeasy.flows.work.Work;
-import org.jeasy.flows.work.WorkReportPredicate;
 import org.jeasy.flows.work.WorkReport;
-
-import java.util.UUID;
+import org.jeasy.flows.work.WorkReportPredicate;
 
 /**
  * A repeat flow executes a work repeatedly until its report is satisfied by a given predicate.
@@ -37,63 +34,63 @@ import java.util.UUID;
  */
 public class RepeatFlow extends AbstractWorkFlow {
 
+  private Work work;
+  private WorkReportPredicate predicate;
+
+  RepeatFlow(String name, Work work, WorkReportPredicate predicate) {
+    super(name);
+    this.work = work;
+    this.predicate = predicate;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public WorkReport call(List param) {
+    WorkReport workReport;
+    do {
+      workReport = work.call(param);
+    } while (predicate.apply(workReport));
+    return workReport;
+  }
+
+  public static class Builder {
+
+    private String name;
     private Work work;
     private WorkReportPredicate predicate;
 
-    RepeatFlow(String name, Work work, WorkReportPredicate predicate) {
-        super(name);
-        this.work = work;
-        this.predicate = predicate;
+    private Builder() {
+      this.name = UUID.randomUUID().toString();
+      this.work = new NoOpWork();
+      this.predicate = WorkReportPredicate.ALWAYS_FALSE;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public WorkReport call() {
-        WorkReport workReport;
-        do {
-            workReport = work.call();
-        } while (predicate.apply(workReport));
-        return workReport;
+    public static RepeatFlow.Builder aNewRepeatFlow() {
+      return new RepeatFlow.Builder();
     }
 
-    public static class Builder {
-
-        private String name;
-        private Work work;
-        private WorkReportPredicate predicate;
-
-        private Builder() {
-            this.name = UUID.randomUUID().toString();
-            this.work = new NoOpWork();
-            this.predicate = WorkReportPredicate.ALWAYS_FALSE;
-        }
-
-        public static RepeatFlow.Builder aNewRepeatFlow() {
-            return new RepeatFlow.Builder();
-        }
-
-        public RepeatFlow.Builder named(String name) {
-            this.name = name;
-            return this;
-        }
-
-        public RepeatFlow.Builder repeat(Work work) {
-            this.work = work;
-            return this;
-        }
-
-        public RepeatFlow.Builder times(int times) {
-            return until(WorkReportPredicate.TimesPredicate.times(times));
-        }
-
-        public RepeatFlow.Builder until(WorkReportPredicate predicate) {
-            this.predicate = predicate;
-            return this;
-        }
-
-        public RepeatFlow build() {
-            return new RepeatFlow(name, work, predicate);
-        }
+    public RepeatFlow.Builder named(String name) {
+      this.name = name;
+      return this;
     }
+
+    public RepeatFlow.Builder repeat(Work work) {
+      this.work = work;
+      return this;
+    }
+
+    public RepeatFlow.Builder times(int times) {
+      return until(WorkReportPredicate.TimesPredicate.times(times));
+    }
+
+    public RepeatFlow.Builder until(WorkReportPredicate predicate) {
+      this.predicate = predicate;
+      return this;
+    }
+
+    public RepeatFlow build() {
+      return new RepeatFlow(name, work, predicate);
+    }
+  }
 }

--- a/src/main/java/org/jeasy/flows/workflow/RepeatFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/RepeatFlow.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import org.jeasy.flows.work.NoOpWork;
 import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.work.WorkReportPredicate;
 
@@ -46,10 +47,10 @@ public class RepeatFlow extends AbstractWorkFlow {
   /**
    * {@inheritDoc}
    */
-  public WorkReport call(List param) {
+  public WorkReport call(List param, WorkContext context) {
     WorkReport workReport;
     do {
-      workReport = work.call(param);
+      workReport = work.call(param, context);
     } while (predicate.apply(workReport));
     return workReport;
   }

--- a/src/main/java/org/jeasy/flows/workflow/SequentialFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/SequentialFlow.java
@@ -1,38 +1,34 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
-import org.jeasy.flows.work.Work;
-import org.jeasy.flows.work.WorkReport;
-
+import static org.jeasy.flows.work.WorkStatus.FAILED;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static org.jeasy.flows.work.WorkStatus.FAILED;
+import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkReport;
 
 /**
  * A sequential flow executes a set of works in sequence.
@@ -43,61 +39,64 @@ import static org.jeasy.flows.work.WorkStatus.FAILED;
  */
 public class SequentialFlow extends AbstractWorkFlow {
 
-    private static final Logger LOGGER = Logger.getLogger(SequentialFlow.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(SequentialFlow.class.getName());
 
-    private List<Work> works = new ArrayList<>();
+  private List<Work> works = new ArrayList<>();
 
-    SequentialFlow(String name, List<Work> works) {
-        super(name);
-        this.works.addAll(works);
+  SequentialFlow(String name, List<Work> works) {
+    super(name);
+    this.works.addAll(works);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public WorkReport call(List param) {
+    WorkReport workReport = null;
+    List rs = param;
+    for (Work work : works) {
+      workReport = work.call(rs);
+      rs = Arrays.asList(workReport);
+      if (workReport != null && FAILED.equals(workReport.getStatus())) {
+        LOGGER.log(Level.INFO, "Work ''{0}'' has failed, skipping subsequent works",
+            work.getName());
+        break;
+      }
+    }
+    return workReport;
+  }
+
+  public static class Builder {
+
+    private String name;
+    private List<Work> works;
+
+    private Builder() {
+      this.name = UUID.randomUUID().toString();
+      this.works = new ArrayList<>();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public WorkReport call() {
-        WorkReport workReport = null;
-        for (Work work : works) {
-            workReport = work.call();
-            if (workReport != null && FAILED.equals(workReport.getStatus())) {
-                LOGGER.log(Level.INFO, "Work ''{0}'' has failed, skipping subsequent works", work.getName());
-                break;
-            }
-        }
-        return workReport;
+    public static SequentialFlow.Builder aNewSequentialFlow() {
+      return new SequentialFlow.Builder();
     }
 
-    public static class Builder {
-
-        private String name;
-        private List<Work> works;
-
-        private Builder() {
-            this.name = UUID.randomUUID().toString();
-            this.works = new ArrayList<>();
-        }
-
-        public static SequentialFlow.Builder aNewSequentialFlow() {
-            return new SequentialFlow.Builder();
-        }
-
-        public SequentialFlow.Builder named(String name) {
-            this.name = name;
-            return this;
-        }
-
-        public SequentialFlow.Builder execute(Work work) {
-            this.works.add(work);
-            return this;
-        }
-
-        public SequentialFlow.Builder then(Work work) {
-            this.works.add(work);
-            return this;
-        }
-
-        public SequentialFlow build() {
-            return new SequentialFlow(name, works);
-        }
+    public SequentialFlow.Builder named(String name) {
+      this.name = name;
+      return this;
     }
+
+    public SequentialFlow.Builder execute(Work work) {
+      this.works.add(work);
+      return this;
+    }
+
+    public SequentialFlow.Builder then(Work work) {
+      this.works.add(work);
+      return this;
+    }
+
+    public SequentialFlow build() {
+      return new SequentialFlow(name, works);
+    }
+  }
 }

--- a/src/main/java/org/jeasy/flows/workflow/SequentialFlow.java
+++ b/src/main/java/org/jeasy/flows/workflow/SequentialFlow.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 
 /**
@@ -51,11 +52,11 @@ public class SequentialFlow extends AbstractWorkFlow {
   /**
    * {@inheritDoc}
    */
-  public WorkReport call(List param) {
+  public WorkReport call(List param, WorkContext context) {
     WorkReport workReport = null;
     List rs = param;
     for (Work work : works) {
-      workReport = work.call(rs);
+      workReport = work.call(rs, context);
       rs = Arrays.asList(workReport);
       if (workReport != null && FAILED.equals(workReport.getStatus())) {
         LOGGER.log(Level.INFO, "Work ''{0}'' has failed, skipping subsequent works",

--- a/src/test/java/org/jeasy/flows/engine/WorkFlowEngineImplTest.java
+++ b/src/test/java/org/jeasy/flows/engine/WorkFlowEngineImplTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.util.Maps;
 import org.jeasy.flows.work.DefaultWorkReport;
 import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.work.WorkStatus;
 import org.jeasy.flows.workflow.ConditionalFlow;
@@ -52,10 +53,10 @@ public class WorkFlowEngineImplTest {
     WorkFlow workFlow = Mockito.mock(WorkFlow.class);
 
     // when
-    workFlowEngine.run(workFlow);
+    workFlowEngine.run(workFlow, null);
 
     // then
-    Mockito.verify(workFlow).call(null);
+    Mockito.verify(workFlow).call(null, null);
   }
 
   /**
@@ -87,7 +88,7 @@ public class WorkFlowEngineImplTest {
         aNewSequentialFlow().execute(repeatFlow).then(conditionalFlow).build();
 
     WorkFlowEngine workFlowEngine = aNewWorkFlowEngine().build();
-    WorkReport workReport = workFlowEngine.run(sequentialFlow);
+    WorkReport workReport = workFlowEngine.run(sequentialFlow, null);
     System.out.println("workflow report = " + workReport);
   }
 
@@ -124,7 +125,7 @@ public class WorkFlowEngineImplTest {
       return name;
     }
 
-    public WorkReport call(List param) {
+    public WorkReport call(List param, WorkContext context) {
       System.out.println("---------------new work---------------");
       if (param != null) {
         System.out.println("*********pre work data start **********");

--- a/src/test/java/org/jeasy/flows/workflow/ConditionalFlowTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/ConditionalFlowTest.java
@@ -39,12 +39,12 @@ public class ConditionalFlowTest {
             .then(nextOnPredicateSuccess).otherwise(nextOnPredicateFailure).build();
 
     // when
-    conditionalFlow.call(null);
+    conditionalFlow.call(null, null);
 
     // then
-    Mockito.verify(toExecute, Mockito.times(1)).call(null);
-    Mockito.verify(nextOnPredicateSuccess, Mockito.times(1)).call(null);
-    Mockito.verify(nextOnPredicateFailure, Mockito.never()).call(null);
+    Mockito.verify(toExecute, Mockito.times(1)).call(null, null);
+    Mockito.verify(nextOnPredicateSuccess, Mockito.times(1)).call(null, null);
+    Mockito.verify(nextOnPredicateFailure, Mockito.never()).call(null, null);
   }
 
   @Test
@@ -59,12 +59,12 @@ public class ConditionalFlowTest {
             .then(nextOnPredicateSuccess).otherwise(nextOnPredicateFailure).build();
 
     // when
-    conditionalFlow.call(null);
+    conditionalFlow.call(null, null);
 
     // then
-    Mockito.verify(toExecute, Mockito.times(1)).call(null);
-    Mockito.verify(nextOnPredicateFailure, Mockito.times(1)).call(null);
-    Mockito.verify(nextOnPredicateSuccess, Mockito.never()).call(null);
+    Mockito.verify(toExecute, Mockito.times(1)).call(null, null);
+    Mockito.verify(nextOnPredicateFailure, Mockito.times(1)).call(null, null);
+    Mockito.verify(nextOnPredicateSuccess, Mockito.never()).call(null, null);
   }
 
 }

--- a/src/test/java/org/jeasy/flows/workflow/ConditionalFlowTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/ConditionalFlowTest.java
@@ -1,25 +1,22 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
@@ -30,50 +27,44 @@ import org.mockito.Mockito;
 
 public class ConditionalFlowTest {
 
-    @Test
-    public void callOnPredicateSuccess() {
-        // given
-        Work toExecute = Mockito.mock(Work.class);
-        Work nextOnPredicateSuccess = Mockito.mock(Work.class);
-        Work nextOnPredicateFailure = Mockito.mock(Work.class);
-        WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_TRUE;
-        ConditionalFlow conditionalFlow = ConditionalFlow.Builder.aNewConditionalFlow()
-                .execute(toExecute)
-                .when(predicate)
-                .then(nextOnPredicateSuccess)
-                .otherwise(nextOnPredicateFailure)
-                .build();
+  @Test
+  public void callOnPredicateSuccess() {
+    // given
+    Work toExecute = Mockito.mock(Work.class);
+    Work nextOnPredicateSuccess = Mockito.mock(Work.class);
+    Work nextOnPredicateFailure = Mockito.mock(Work.class);
+    WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_TRUE;
+    ConditionalFlow conditionalFlow =
+        ConditionalFlow.Builder.aNewConditionalFlow().execute(toExecute).when(predicate)
+            .then(nextOnPredicateSuccess).otherwise(nextOnPredicateFailure).build();
 
-        // when
-        conditionalFlow.call();
+    // when
+    conditionalFlow.call(null);
 
-        // then
-        Mockito.verify(toExecute, Mockito.times(1)).call();
-        Mockito.verify(nextOnPredicateSuccess, Mockito.times(1)).call();
-        Mockito.verify(nextOnPredicateFailure, Mockito.never()).call();
-    }
+    // then
+    Mockito.verify(toExecute, Mockito.times(1)).call(null);
+    Mockito.verify(nextOnPredicateSuccess, Mockito.times(1)).call(null);
+    Mockito.verify(nextOnPredicateFailure, Mockito.never()).call(null);
+  }
 
-    @Test
-    public void callOnPredicateFailure() {
-        // given
-        Work toExecute = Mockito.mock(Work.class);
-        Work nextOnPredicateSuccess = Mockito.mock(Work.class);
-        Work nextOnPredicateFailure = Mockito.mock(Work.class);
-        WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_FALSE;
-        ConditionalFlow conditionalFlow = ConditionalFlow.Builder.aNewConditionalFlow()
-                .execute(toExecute)
-                .when(predicate)
-                .then(nextOnPredicateSuccess)
-                .otherwise(nextOnPredicateFailure)
-                .build();
+  @Test
+  public void callOnPredicateFailure() {
+    // given
+    Work toExecute = Mockito.mock(Work.class);
+    Work nextOnPredicateSuccess = Mockito.mock(Work.class);
+    Work nextOnPredicateFailure = Mockito.mock(Work.class);
+    WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_FALSE;
+    ConditionalFlow conditionalFlow =
+        ConditionalFlow.Builder.aNewConditionalFlow().execute(toExecute).when(predicate)
+            .then(nextOnPredicateSuccess).otherwise(nextOnPredicateFailure).build();
 
-        // when
-        conditionalFlow.call();
+    // when
+    conditionalFlow.call(null);
 
-        // then
-        Mockito.verify(toExecute, Mockito.times(1)).call();
-        Mockito.verify(nextOnPredicateFailure, Mockito.times(1)).call();
-        Mockito.verify(nextOnPredicateSuccess, Mockito.never()).call();
-    }
+    // then
+    Mockito.verify(toExecute, Mockito.times(1)).call(null);
+    Mockito.verify(nextOnPredicateFailure, Mockito.times(1)).call(null);
+    Mockito.verify(nextOnPredicateSuccess, Mockito.never()).call(null);
+  }
 
 }

--- a/src/test/java/org/jeasy/flows/workflow/HelloWorldWork.java
+++ b/src/test/java/org/jeasy/flows/workflow/HelloWorldWork.java
@@ -12,6 +12,7 @@
 
 package org.jeasy.flows.workflow;
 
+import java.util.List;
 import org.assertj.core.util.Maps;
 import org.jeasy.flows.work.DefaultWorkReport;
 import org.jeasy.flows.work.Work;
@@ -42,7 +43,7 @@ public class HelloWorldWork implements Work<String> {
   }
 
   @Override
-  public WorkReport<String> call() {
+  public WorkReport<String> call(List param) {
     executed = true;
     DefaultWorkReport<String> dwr = new DefaultWorkReport<String>(status);
     dwr.setCollectData(Maps.newHashMap(name, "hello"));

--- a/src/test/java/org/jeasy/flows/workflow/HelloWorldWork.java
+++ b/src/test/java/org/jeasy/flows/workflow/HelloWorldWork.java
@@ -1,5 +1,5 @@
 /**
- * All rights Reserved, Designed By www.didichuxing.com.
+ * All rights Reserved
  * 
  * @Title: t.java <\br>
  * @Package org.jeasy.flows.workflow <\br>
@@ -7,7 +7,7 @@
  * @author: zyt <\br>
  * @date: 2018年12月13日 下午5:28:10 <\br>
  * @version V1.0 <\br>
- * @Copyright: 2018 www.didichuxing Inc. All rights reserved.<\br>
+ * @Copyright: 2018 .<\br>
  */
 
 package org.jeasy.flows.workflow;

--- a/src/test/java/org/jeasy/flows/workflow/HelloWorldWork.java
+++ b/src/test/java/org/jeasy/flows/workflow/HelloWorldWork.java
@@ -16,6 +16,7 @@ import java.util.List;
 import org.assertj.core.util.Maps;
 import org.jeasy.flows.work.DefaultWorkReport;
 import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkContext;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.work.WorkStatus;
 
@@ -43,7 +44,7 @@ public class HelloWorldWork implements Work<String> {
   }
 
   @Override
-  public WorkReport<String> call(List param) {
+  public WorkReport<String> call(List param, WorkContext context) {
     executed = true;
     DefaultWorkReport<String> dwr = new DefaultWorkReport<String>(status);
     dwr.setCollectData(Maps.newHashMap(name, "hello"));

--- a/src/test/java/org/jeasy/flows/workflow/HelloWorldWork.java
+++ b/src/test/java/org/jeasy/flows/workflow/HelloWorldWork.java
@@ -1,0 +1,55 @@
+/**
+ * All rights Reserved, Designed By www.didichuxing.com.
+ * 
+ * @Title: t.java <\br>
+ * @Package org.jeasy.flows.workflow <\br>
+ * @Description: TODO(用一句话描述该文件做什么)<\br>
+ * @author: zyt <\br>
+ * @date: 2018年12月13日 下午5:28:10 <\br>
+ * @version V1.0 <\br>
+ * @Copyright: 2018 www.didichuxing Inc. All rights reserved.<\br>
+ */
+
+package org.jeasy.flows.workflow;
+
+import org.assertj.core.util.Maps;
+import org.jeasy.flows.work.DefaultWorkReport;
+import org.jeasy.flows.work.Work;
+import org.jeasy.flows.work.WorkReport;
+import org.jeasy.flows.work.WorkStatus;
+
+/**
+ * @ClassName: t .
+ * @Description:TODO(这里用一句话描述这个类的作用) <\br>
+ * @author: zyt <\br>
+ * @date: 2018年12月13日 下午5:28:10 <\br>
+ * 
+ */
+public class HelloWorldWork implements Work<String> {
+
+  private String name;
+  private WorkStatus status;
+  private boolean executed;
+
+  HelloWorldWork(String name, WorkStatus status) {
+    this.name = name;
+    this.status = status;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public WorkReport<String> call() {
+    executed = true;
+    DefaultWorkReport<String> dwr = new DefaultWorkReport<String>(status);
+    dwr.setCollectData(Maps.newHashMap(name, "hello"));
+    return dwr;
+  }
+
+  public boolean isExecuted() {
+    return executed;
+  }
+}

--- a/src/test/java/org/jeasy/flows/workflow/ParallelFlowExecutorTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/ParallelFlowExecutorTest.java
@@ -39,7 +39,7 @@ public class ParallelFlowExecutorTest {
 
     // when
     List<WorkReport> workReports =
-        parallelFlowExecutor.executeInParallel(Arrays.asList(work1, work2), null);
+        parallelFlowExecutor.executeInParallel(Arrays.asList(work1, work2), null, null);
 
     // then
     Assertions.assertThat(workReports).hasSize(2);

--- a/src/test/java/org/jeasy/flows/workflow/ParallelFlowExecutorTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/ParallelFlowExecutorTest.java
@@ -39,7 +39,7 @@ public class ParallelFlowExecutorTest {
 
     // when
     List<WorkReport> workReports =
-        parallelFlowExecutor.executeInParallel(Arrays.asList(work1, work2));
+        parallelFlowExecutor.executeInParallel(Arrays.asList(work1, work2), null);
 
     // then
     Assertions.assertThat(workReports).hasSize(2);

--- a/src/test/java/org/jeasy/flows/workflow/ParallelFlowExecutorTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/ParallelFlowExecutorTest.java
@@ -1,82 +1,52 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
+import java.util.Arrays;
+import java.util.List;
 import org.assertj.core.api.Assertions;
-import org.jeasy.flows.work.DefaultWorkReport;
-import org.jeasy.flows.work.Work;
 import org.jeasy.flows.work.WorkReport;
 import org.jeasy.flows.work.WorkStatus;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
 public class ParallelFlowExecutorTest {
 
-    @Test
-    public void call() throws Exception {
+  @Test
+  public void call() throws Exception {
 
-        // given
-        HelloWorldWork work1 = new HelloWorldWork("work1", WorkStatus.COMPLETED);
-        HelloWorldWork work2 = new HelloWorldWork("work2", WorkStatus.FAILED);
-        ParallelFlowExecutor parallelFlowExecutor = new ParallelFlowExecutor();
+    // given
+    HelloWorldWork work1 = new HelloWorldWork("work1", WorkStatus.COMPLETED);
+    HelloWorldWork work2 = new HelloWorldWork("work2", WorkStatus.FAILED);
+    ParallelFlowExecutor parallelFlowExecutor = new ParallelFlowExecutor();
 
-        // when
-        List<WorkReport> workReports = parallelFlowExecutor.executeInParallel(Arrays.asList(work1, work2));
+    // when
+    List<WorkReport> workReports =
+        parallelFlowExecutor.executeInParallel(Arrays.asList(work1, work2));
 
-        // then
-        Assertions.assertThat(workReports).hasSize(2);
-        Assertions.assertThat(work1.isExecuted()).isTrue();
-        Assertions.assertThat(work2.isExecuted()).isTrue();
-    }
+    // then
+    Assertions.assertThat(workReports).hasSize(2);
+    Assertions.assertThat(work1.isExecuted()).isTrue();
+    Assertions.assertThat(work2.isExecuted()).isTrue();
+  }
 
-    class HelloWorldWork implements Work {
 
-        private String name;
-        private WorkStatus status;
-        private boolean executed;
-
-        HelloWorldWork(String name, WorkStatus status) {
-            this.name = name;
-            this.status = status;
-        }
-
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public WorkReport call() {
-            executed = true;
-            return new DefaultWorkReport(status);
-        }
-
-        public boolean isExecuted() {
-            return executed;
-        }
-    }
 
 }

--- a/src/test/java/org/jeasy/flows/workflow/ParallelFlowTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/ParallelFlowTest.java
@@ -39,11 +39,11 @@ public class ParallelFlowTest {
     ParallelFlow parallelFlow = new ParallelFlow("pf", works, parallelFlowExecutor);
 
     // when
-    ParallelFlowReport parallelFlowReport = parallelFlow.call(null);
+    ParallelFlowReport parallelFlowReport = parallelFlow.call(null, null);
 
     // then
     Assertions.assertThat(parallelFlowReport).isNotNull();
-    Mockito.verify(parallelFlowExecutor).executeInParallel(works, null);
+    Mockito.verify(parallelFlowExecutor).executeInParallel(works, null, null);
   }
 
 }

--- a/src/test/java/org/jeasy/flows/workflow/ParallelFlowTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/ParallelFlowTest.java
@@ -1,53 +1,49 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
+import java.util.Arrays;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.jeasy.flows.work.Work;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.Arrays;
-import java.util.List;
-
 public class ParallelFlowTest {
 
-    @Test
-    public void call() throws Exception {
-        // given
-        Work work1 = Mockito.mock(Work.class);
-        Work work2 = Mockito.mock(Work.class);
-        ParallelFlowExecutor parallelFlowExecutor = Mockito.mock(ParallelFlowExecutor.class);
-        List<Work> works = Arrays.asList(work1, work2);
-        ParallelFlow parallelFlow = new ParallelFlow("pf", works, parallelFlowExecutor);
+  @Test
+  public void call() throws Exception {
+    // given
+    Work work1 = Mockito.mock(Work.class);
+    Work work2 = Mockito.mock(Work.class);
+    ParallelFlowExecutor parallelFlowExecutor = Mockito.mock(ParallelFlowExecutor.class);
+    List<Work> works = Arrays.asList(work1, work2);
+    ParallelFlow parallelFlow = new ParallelFlow("pf", works, parallelFlowExecutor);
 
-        // when
-        ParallelFlowReport parallelFlowReport = parallelFlow.call();
+    // when
+    ParallelFlowReport parallelFlowReport = parallelFlow.call(null);
 
-        // then
-        Assertions.assertThat(parallelFlowReport).isNotNull();
-        Mockito.verify(parallelFlowExecutor).executeInParallel(works);
-    }
+    // then
+    Assertions.assertThat(parallelFlowReport).isNotNull();
+    Mockito.verify(parallelFlowExecutor).executeInParallel(works, null);
+  }
 
 }

--- a/src/test/java/org/jeasy/flows/workflow/RepeatFlowTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/RepeatFlowTest.java
@@ -36,10 +36,10 @@ public class RepeatFlowTest {
         RepeatFlow.Builder.aNewRepeatFlow().repeat(work).until(predicate).build();
 
     // when
-    repeatFlow.call(null);
+    repeatFlow.call(null, null);
 
     // then
-    Mockito.verify(work, Mockito.times(1)).call(null);
+    Mockito.verify(work, Mockito.times(1)).call(null, null);
   }
 
   @Test
@@ -49,10 +49,10 @@ public class RepeatFlowTest {
     RepeatFlow repeatFlow = RepeatFlow.Builder.aNewRepeatFlow().repeat(work).times(3).build();
 
     // when
-    repeatFlow.call(null);
+    repeatFlow.call(null, null);
 
     // then
-    Mockito.verify(work, Mockito.times(3)).call(null);
+    Mockito.verify(work, Mockito.times(3)).call(null, null);
   }
 
 }

--- a/src/test/java/org/jeasy/flows/workflow/RepeatFlowTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/RepeatFlowTest.java
@@ -1,25 +1,22 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
@@ -30,37 +27,32 @@ import org.mockito.Mockito;
 
 public class RepeatFlowTest {
 
-    @Test
-    public void testRepeatUntil() throws Exception {
-        // given
-        Work work = Mockito.mock(Work.class);
-        WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_FALSE;
-        RepeatFlow repeatFlow = RepeatFlow.Builder.aNewRepeatFlow()
-                .repeat(work)
-                .until(predicate)
-                .build();
+  @Test
+  public void testRepeatUntil() throws Exception {
+    // given
+    Work work = Mockito.mock(Work.class);
+    WorkReportPredicate predicate = WorkReportPredicate.ALWAYS_FALSE;
+    RepeatFlow repeatFlow =
+        RepeatFlow.Builder.aNewRepeatFlow().repeat(work).until(predicate).build();
 
-        // when
-        repeatFlow.call();
+    // when
+    repeatFlow.call(null);
 
-        // then
-        Mockito.verify(work, Mockito.times(1)).call();
-    }
+    // then
+    Mockito.verify(work, Mockito.times(1)).call(null);
+  }
 
-    @Test
-    public void testRepeatTimes() throws Exception {
-        // given
-        Work work = Mockito.mock(Work.class);
-        RepeatFlow repeatFlow = RepeatFlow.Builder.aNewRepeatFlow()
-                .repeat(work)
-                .times(3)
-                .build();
+  @Test
+  public void testRepeatTimes() throws Exception {
+    // given
+    Work work = Mockito.mock(Work.class);
+    RepeatFlow repeatFlow = RepeatFlow.Builder.aNewRepeatFlow().repeat(work).times(3).build();
 
-        // when
-        repeatFlow.call();
+    // when
+    repeatFlow.call(null);
 
-        // then
-        Mockito.verify(work, Mockito.times(3)).call();
-    }
+    // then
+    Mockito.verify(work, Mockito.times(3)).call(null);
+  }
 
 }

--- a/src/test/java/org/jeasy/flows/workflow/SequentialFlowTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/SequentialFlowTest.java
@@ -37,13 +37,13 @@ public class SequentialFlowTest {
         SequentialFlow.Builder.aNewSequentialFlow().execute(work1).then(work2).then(work3).build();
 
     // when
-    sequentialFlow.call(null);
+    sequentialFlow.call(null, null);
 
     // then
     InOrder inOrder = Mockito.inOrder(work1, work2, work3);
-    inOrder.verify(work1, Mockito.times(1)).call(null);
-    inOrder.verify(work2, Mockito.times(1)).call(null);
-    inOrder.verify(work3, Mockito.times(1)).call(null);
+    inOrder.verify(work1, Mockito.times(1)).call(null, null);
+    inOrder.verify(work2, Mockito.times(1)).call(null, null);
+    inOrder.verify(work3, Mockito.times(1)).call(null, null);
   }
 
 }

--- a/src/test/java/org/jeasy/flows/workflow/SequentialFlowTest.java
+++ b/src/test/java/org/jeasy/flows/workflow/SequentialFlowTest.java
@@ -1,25 +1,22 @@
 /**
  * The MIT License
  *
- *  Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in
- *  all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *  THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package org.jeasy.flows.workflow;
 
@@ -30,26 +27,23 @@ import org.mockito.Mockito;
 
 public class SequentialFlowTest {
 
-    @Test
-    public void call() throws Exception {
-        // given
-        Work work1 = Mockito.mock(Work.class);
-        Work work2 = Mockito.mock(Work.class);
-        Work work3 = Mockito.mock(Work.class);
-        SequentialFlow sequentialFlow = SequentialFlow.Builder.aNewSequentialFlow()
-                .execute(work1)
-                .then(work2)
-                .then(work3)
-                .build();
+  @Test
+  public void call() throws Exception {
+    // given
+    Work work1 = Mockito.mock(Work.class);
+    Work work2 = Mockito.mock(Work.class);
+    Work work3 = Mockito.mock(Work.class);
+    SequentialFlow sequentialFlow =
+        SequentialFlow.Builder.aNewSequentialFlow().execute(work1).then(work2).then(work3).build();
 
-        // when
-        sequentialFlow.call();
+    // when
+    sequentialFlow.call(null);
 
-        // then
-        InOrder inOrder = Mockito.inOrder(work1, work2, work3);
-        inOrder.verify(work1, Mockito.times(1)).call();
-        inOrder.verify(work2, Mockito.times(1)).call();
-        inOrder.verify(work3, Mockito.times(1)).call();
-    }
+    // then
+    InOrder inOrder = Mockito.inOrder(work1, work2, work3);
+    inOrder.verify(work1, Mockito.times(1)).call(null);
+    inOrder.verify(work2, Mockito.times(1)).call(null);
+    inOrder.verify(work3, Mockito.times(1)).call(null);
+  }
 
 }


### PR DESCRIPTION
current pre-worker only export WordReport status for judge the flow whether run continue.

but some scene，post worker want to fetch pre worker result .so i modify some code to support post-worker  can fetch pre-worker result.
1, in condition flow , toExecute use pre-worker result. nextOnPredicateSuccess and nextOnPredicateFailure can use toExecute result.
2.in ParallelFlow, each worker use one pre-worker result and produce List<WorkerReport> to post-worker.
3.in sequence flow ,each worker use pre run worker result.but the first use pre-worker result.


