### PR TITLE
Changed ParallelFlowExecutor to use a CountDownLatch

### DIFF
--- a/src/main/java/org/jeasy/flows/workflow/ParallelFlowExecutor.java
+++ b/src/main/java/org/jeasy/flows/workflow/ParallelFlowExecutor.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -50,27 +51,35 @@ class ParallelFlowExecutor {
     List<WorkReport> executeInParallel(List<Work> works, WorkContext workContext) {
         // submit work units to be executed in parallel
         Map<Work, Future<WorkReport>> reportFutures = new HashMap<>();
+
+        CountDownLatch latch = new CountDownLatch(works.size());
+
         for (Work work : works) {
-            Future<WorkReport> reportFuture = workExecutor.submit(() -> work.call(workContext));
+            Future<WorkReport> reportFuture = workExecutor.submit(() -> {
+                try {
+                    return work.call(workContext);
+                } finally {
+                    latch.countDown();
+                }
+            });
             reportFutures.put(work, reportFuture);
         }
 
-        // poll for work completion
-        int finishedWorks = works.size();
-        // FIXME polling futures for completion, not sure this is the best way to run callables in parallel and wait for them to complete (use CompletionService??)
-        while (finishedWorks > 0) {
-            for (Future<WorkReport> future : reportFutures.values()) {
-                if (future != null && future.isDone()) {
-                        finishedWorks--;
-                }
-            }
+        try {
+            // wait for the work completion
+            latch.await();
+        } catch(InterruptedException e) {
+            LOGGER.log(Level.WARNING, "Unable to complete all work units", e);
         }
 
         // gather reports
         List<WorkReport> workReports = new ArrayList<>();
         for (Map.Entry<Work, Future<WorkReport>> entry : reportFutures.entrySet()) {
             try {
-                workReports.add(entry.getValue().get());
+                // If the CountDownLatch was interrupted not all work may have completed.
+                if(entry.getValue().isDone()) {
+                    workReports.add(entry.getValue().get());
+                }
             } catch (InterruptedException | ExecutionException e) {
                 LOGGER.log(Level.WARNING, "Unable to get report of work unit ''{0}''", entry.getKey().getName());
             }


### PR DESCRIPTION
This PR addresses the FIXME in the` ParallelFlowExecutor` by replacing the polling with a [CountDownLatch](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/CountDownLatch.html) when waiting for work completion.

A few things to note:

- This allows `executeInParallel` to be Interrupted and if so, will not wait for the rest of the work units to finish. This is why the `isDone` check is added to the final loop. This was added for a specific reason for my project but may not be desired behaviour overall. 

- The FIXME suggests using a `CompletionService` which would have worked as well but I don't believe having a blocking queue would have added much benefit in this case since we want to gather all the results at the end anyway. 

Happy to hear some thoughts/feedback
